### PR TITLE
Require Ruby 2.7 (Drop Ruby 2.5 and 2.6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 require: rubocop-minitest
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Enabled: false

--- a/rack-simple_user_agent.gemspec
+++ b/rack-simple_user_agent.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
 end


### PR DESCRIPTION
- Require Ruby 2.7 or more
- Drop Ruby 2.5 & 2.6